### PR TITLE
Upgrade to Debian Bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 
 LABEL version="0.2.0"
 LABEL repository="https://github.com/franzliedke/gh-action-php"
@@ -14,7 +14,7 @@ LABEL com.github.actions.color="purple"
 RUN apt-get update && \
       apt-get install -y apt-transport-https curl gnupg2 && \
       curl https://packages.sury.org/php/apt.gpg | apt-key add - && \
-      echo 'deb https://packages.sury.org/php/ stretch main' > /etc/apt/sources.list.d/deb.sury.org.list && \
+      echo 'deb https://packages.sury.org/php/ bullseye main' > /etc/apt/sources.list.d/deb.sury.org.list && \
       apt-get update && \
       apt-get install -y php5.6-cli php7.0-cli php7.1-cli php7.2-cli php7.3-cli
-
+      

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,3 @@ RUN apt-get update && \
       echo 'deb https://packages.sury.org/php/ bullseye main' > /etc/apt/sources.list.d/deb.sury.org.list && \
       apt-get update && \
       apt-get install -y php5.6-cli php7.0-cli php7.1-cli php7.2-cli php7.3-cli
-      


### PR DESCRIPTION
GitHub Actions finishes with a error code. Since the repo "deb.sury.org" deleted support for PHP packages for Debian Stretch.

See: https://twitter.com/debsuryorg/status/1543122136990089221?s=20&t=Rl8bBoXdhNVlQH8W-Jj3Mw

## Error log:

```bash
  W: The repository 'https://packages.sury.org/php stretch Release' does not have a Release file.
  E: Failed to fetch https://packages.sury.org/php/dists/stretch/main/binary-amd64/Packages  403  Forbidden
  E: Some index files failed to download. They have been ignored, or old ones used instead.
  The command '/bin/sh -c apt-get update &&       apt-get install -y apt-transport-https curl gnupg2 &&       curl https://packages.sury.org/php/apt.gpg | apt-key add - &&       echo 'deb https://packages.sury.org/php/ stretch main' > /etc/apt/sources.list.d/deb.sury.org.list &&       apt-get update &&       apt-get install -y php5.6-cli php7.0-cli php7.1-cli php7.2-cli php7.3-cli' returned a non-zero code: 100
  
Error: Docker build failed with exit code 100
```